### PR TITLE
hotplug monitors

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -34,6 +34,7 @@ const SETTINGS_SCHEMA = 'org.gnome.shell.extensions.tidalwm';
 
 var displaySignals = [];
 var settingsSignals = [];
+var monitorSignals = [];
 var extension;
 
 class Extension {
@@ -136,12 +137,18 @@ class Extension {
                         || op == 20481  // resize (sw)
                         || op == 16385  // resize (s)
                         || op == 32769  // resize (n)
-                        || op == 4097   //  resize (w)
-                        || op == 8193   //  resize (e)
+                        || op == 4097   // resize (w)
+                        || op == 8193   // resize (e)
                         || op == 1)) {  // move
                             this._tidal.resetWindow(window);
                     }
                 }
+            })
+        );
+
+        monitorSignals.push(
+            Meta.MonitorManager.get().connect("monitors-changed", (monitors) => {
+                this._tidal.setupPools();
             })
         );
 

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
     "shell-version": [
         "3.34"
     ],
-    "version": 1,
+    "version": 2,
     "url": "https://github.com/rustysec/tidalwm",
     "settings-schema": "org.gnome.shell.extensions.tidalwm",
     "gettext-domain": "tidalwm@rustysec.github.io"

--- a/tidal.js
+++ b/tidal.js
@@ -24,10 +24,9 @@ var Tidal = class TidalClass {
             });
 
             this.cacheWindows(workspace);
-            for (var j = 0; j < workspace.get_display().get_n_monitors(); j++) {
-                this.pools[`${i}-${j}`] = new Me.imports.pool.Pool(this.settings, i, j);
-            }
         }
+
+        this.setupPools();
     }
 
     // adds a window to Tidal's management system
@@ -190,6 +189,19 @@ var Tidal = class TidalClass {
                         };
                     }
                 });
+        }
+    }
+
+    // ensure there is a window pool for each monitor on every workspace
+    setupPools() {
+        for (var i = 0; i < global.workspace_manager.get_n_workspaces(); i++) {
+            let workspace = global.workspace_manager.get_workspace_by_index(i);
+
+            for (var j = 0; j < workspace.get_display().get_n_monitors(); j++) {
+                if (!pools[`${i}-${j}`]) {
+                    this.pools[`${i}-${j}`] = new Me.imports.pool.Pool(this.settings, i, j);
+                }
+            }
         }
     }
 

--- a/tidal.js
+++ b/tidal.js
@@ -198,7 +198,7 @@ var Tidal = class TidalClass {
             let workspace = global.workspace_manager.get_workspace_by_index(i);
 
             for (var j = 0; j < workspace.get_display().get_n_monitors(); j++) {
-                if (!pools[`${i}-${j}`]) {
+                if (!this.pools[`${i}-${j}`]) {
                     this.pools[`${i}-${j}`] = new Me.imports.pool.Pool(this.settings, i, j);
                 }
             }


### PR DESCRIPTION
detects new monitor(s) and sets them up in with a window pool for tidalwm. unplugging the monitor doesn't destroy the existing pool, but all of the windows are drained from it by standard gnome events.

closes #11 