### PR TITLE
Add flag for shallow clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ options in development.
 ## Installing
 Clone this repo:
 ```sh
-git clone https://github.com/rustysec/tidalwm \
+git clone --depth=1 \
+    https://github.com/rustysec/tidalwm \
     ~/.local/share/gnome-shell/extensions/tidalwm@rustysec.github.io
 ```
 


### PR DESCRIPTION
Small update to readme. Added the `--depth=1` flag to the git clone command. Thought it might be helpful to save a few bytes of disk and network for folks who copy-paste the instructions and don't care to browse the git history.