### PR TITLE
backwards compatibility for earlier versions of Gnome Shell

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -220,11 +220,11 @@ class Extension {
             })
         );
 
-        workspaceManagerSignals.push(
-            global.workspace_manager.connect("workspaces-reordered", () => {
-                /// placeholder
-            })
-        );
+        // workspaceManagerSignals.push(
+        //     global.workspace_manager.connect("workspaces-reordered", () => {
+        //         /// placeholder
+        //     })
+        // );
 
         workspaceManagerSignals.push(
             global.workspace_manager.connect("active-workspace-changed", () => {


### PR DESCRIPTION
There isn't any code here anyway.  It shouldn't be a show stopper on the stable branch.